### PR TITLE
修复web端carousel在快速滑动下，超出页面边界，导致JS报错问题。

### DIFF
--- a/src/components/carousel/carousel.web.cml
+++ b/src/components/carousel/carousel.web.cml
@@ -211,12 +211,14 @@ class Carousel implements CCarouselInterface {
         }
         // 遍历子集
         let $sliderChildren = $slider.children[0].children
-        let offsetLeft = $sliderChildren[lastPage].offsetLeft
-        if (this.circular) {
-          offsetLeft = $sliderChildren[lastPage].offsetLeft
-        }
+        const current = $sliderChildren[lastPage]
+        if (!current) return
+        let offsetLeft = current.offsetLeft
+        // if (this.circular) {
+        //   offsetLeft = current.offsetLeft
+        // }
         // 居中
-        let offsetWidth = $sliderChildren[lastPage].offsetWidth
+        let offsetWidth = current.offsetWidth
         let slidesPerView = this.options.slidesPerView
         let sliderLength = this.s_data.sliderLength
         if (this.options.centeredSlides) {

--- a/src/components/carousel/carousel.web.cml
+++ b/src/components/carousel/carousel.web.cml
@@ -214,9 +214,7 @@ class Carousel implements CCarouselInterface {
         const current = $sliderChildren[lastPage]
         if (!current) return
         let offsetLeft = current.offsetLeft
-        // if (this.circular) {
-        //   offsetLeft = current.offsetLeft
-        // }
+
         // 居中
         let offsetWidth = current.offsetWidth
         let slidesPerView = this.options.slidesPerView


### PR DESCRIPTION
修复web端carousel在快速滑动下，超出页面边界，导致JS报错问题。顺手做了点优化。

![avatar](https://tiktok.oss-cn-shanghai.aliyuncs.com/avatar/WechatIMG141.png)