### PR TITLE
修改carousel中tap事件和touch事件的区分，tap事件时不传递change事件

### DIFF
--- a/src/components/carousel/carousel.web.cml
+++ b/src/components/carousel/carousel.web.cml
@@ -3,6 +3,7 @@
       <view 
         class="slider-touch"
         style="{{styleStr}}"
+        c-bind:tap="tapAction"
         c-bind:touchmove="swipeMove"
         c-bind:touchstart="swipeStart"
         c-bind:mousedown="swipeStart"
@@ -118,6 +119,7 @@ class Carousel implements CCarouselInterface {
   }
   name =  'slider'
   data = {
+    isTap:false,
     pages: [],
     options: {
       preventDocumentMove: true
@@ -409,6 +411,10 @@ class Carousel implements CCarouselInterface {
     window.removeEventListener('resize', this.resize)
   }
   methods = {
+    tapAction(e){
+      console.log("tapAction", e);
+      this.isTap = true;
+    },
     visibilitychange () {
       let that = this
       if (document.hidden) {
@@ -428,6 +434,7 @@ class Carousel implements CCarouselInterface {
       this.slide(this.data.currentPage, 'animationnone')
     },
     swipeStart (e) {
+      console.log("swipeStart", e, this.isTap);
       let that = this
       this.s_data.e = e
       if (this.s_data.freeze) {
@@ -476,6 +483,8 @@ class Carousel implements CCarouselInterface {
       }
     },
     swipeMove (e) {
+      this.isTap = false;
+      console.log("swipeMove", e, this.isTap);
       this.s_data.e = e
       if (this.s_data.tracking) {
         let effect = this.s_data.effect
@@ -535,6 +544,10 @@ class Carousel implements CCarouselInterface {
       }
     },
     swipeEnd (e) {
+      console.log("swipeEnd", e, this.isTap);
+      if (this.isTap) {
+        return;
+      }
       document.removeEventListener('touchend', this.swipeEnd);
       this.s_data.e = e
       this.s_data.tracking = false

--- a/src/pages/example/carousel/carousel.cml
+++ b/src/pages/example/carousel/carousel.cml
@@ -1,46 +1,88 @@
 <template>
-  <c-page title="carousel">
-    <c-header title="carousel"></c-header>
-    <carousel class="container" indicator-dots="{{true}}"  current="{{0}}" circular="{{true}}" autoplay="{{true}}" interval="{{2000}}">
-      <carousel-item>
-        <view  class="carousel-item" style="background-color: #EBDEAA"></view>
-      </carousel-item>
-      <carousel-item>
-        <view class="carousel-item" style="background-color: #E3EDCD"></view>
-      </carousel-item>
-      <carousel-item>
-        <view class="carousel-item" style="background-color: #EAEAEF"></view>
-      </carousel-item>
-    </carousel>
-  </c-page>
+<c-page title="carousel">
+  <c-header title="carousel"></c-header>
+  <carousel class="container" indicator-dots="{{true}}" current="{{0}}" circular="{{true}}" autoplay="{{true}}" interval="{{2000}}">
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #EBDEAA"></view>
+    </carousel-item>
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #E3EDCD"></view>
+    </carousel-item>
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #EAEAEF"></view>
+    </carousel-item>
+  </carousel>
+
+  <c-header title="carousel-item内部按钮控制切换"></c-header>
+  <carousel class="container" indicator-dots="{{true}}" current="{{position}}" circular="{{false}}" autoplay="{{false}}" interval="{{2000}}" c-bind:change="change">
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #EBDEAA">
+        <view class="btn" c-bind:tap="go()">
+          <text>跳转</text></view>
+      </view>
+    </carousel-item>
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #E3EDCD"></view>
+    </carousel-item>
+    <carousel-item>
+      <view class="carousel-item" style="background-color: #EAEAEF"></view>
+    </carousel-item>
+  </carousel>
+</c-page>
 </template>
 <script>
-  class Carousel {}
+class Carousel {
 
-  export default new Carousel();
+  data = {
+    position: 0
+  }
 
+  methods = {
+    go() {
+      this.position = 2;
+    },
+    change(e){
+      console.log("change", e);
+      this.position = e.detail.current;
+    }
+  }
+}
+
+export default new Carousel();
 </script>
 
 <style scoped>
 .container {
   height: 300cpx;
 }
+
 .carousel-item {
   height: 300cpx;
   width: 750cpx;
+  align-items: center;
+  justify-content: center
+}
+
+.btn {
+  width: 120cpx;
+  color: white;
+  background-color: red;
+  border-radius: 10cpx;
+  align-items: center;
+  justify-content: center;
 }
 </style>
 
 <script cml-type="json">
 {
-  "base": {
-    "usingComponents": {
-      "c-page": "/components/page/page",
-      "c-header": "../../components/header/header",
-      "carousel": "/components/carousel/carousel",
-      "carousel-item": "/components/carousel-item/carousel-item"
-    }
-  }
+		"base": {
+				"usingComponents": {
+						"c-page": "/components/page/page",
+						"c-header": "../../components/header/header",
+						"carousel": "/components/carousel/carousel",
+						"carousel-item": "/components/carousel-item/carousel-item"
+				}
+		}
 }
 </script>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29418341/87960623-2679e400-cae7-11ea-8cb3-cd93527d05e5.png)
问题：
       在carousel与c-tab结合处理联动场景时，carousel-item中触发切换至其他的tabitem页签，carousel中点击时change事件会一直触发且传递出来的current为0，无法顺利执行切换页签的操作；
理想状态：
      将carousel中的tap事件和touch事件区分，tap事件时不传递change事件，touchmove的时候传递change事件；
处理办法：
添加isTap变量，在tapAction和touchStart、touchEnd中进行状态维护，touchEnd中如果isTap = true直接return, 不传递change事件；